### PR TITLE
Migrate original image to dolibarr/dolibarr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tuxgasy/dolibarr
+FROM dolibarr/dolibarr
 ENV PHP_INI_UPLOAD_SIZE 40M
 RUN sed -i -e 's/memory_limit = ${PHP_INI_MEMORY_LIMIT}/memory_limit = ${PHP_INI_MEMORY_LIMIT}\n upload_max_filesize = ${PHP_INI_UPLOAD_SIZE}\n post_max_size= ${PHP_INI_UPLOAD_SIZE}/g' /usr/local/bin/docker-run.sh
 RUN sed -i -e 's|//config.entities = false;|config.entities = false;|g' \


### PR DESCRIPTION
Tuxgasi/dolibarr is now deprecated and replaced by 
 [dolibarr/dolibarr](https://github.com/vincowl/dolibarr_docker)